### PR TITLE
#65: Only install husky git hooks when not on production.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tdd": "jest --runInBand --watch",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --no-cache --ci --reporters='default' --reporters='jest-junit'",
-    "prepare": "husky install"
+    "prepare": "if [ ${NODE_ENV} != 'production' ]; then husky install; fi"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## 2.0.7
* [#65: Update dependencies.](https://github.com/haensl/react-component-console/issues/65)

Closes #65